### PR TITLE
Add support for dynamic food items

### DIFF
--- a/common/src/main/java/vice/sol_valheim/FoodHUD.java
+++ b/common/src/main/java/vice/sol_valheim/FoodHUD.java
@@ -81,7 +81,7 @@ public class FoodHUD implements ClientGuiEvent.RenderHud
         if (foodConfig == null)
             return;
 
-        var isDrink = food.item.getDefaultInstance().getUseAnimation() == UseAnim.DRINK;
+        var isDrink = food.item.getUseAnimation() == UseAnim.DRINK;
         int bgColor = isDrink ? FastColor.ARGB32.color(96, 52, 104, 163) : FastColor.ARGB32.color(96, 0, 0, 0);
         int yellow = FastColor.ARGB32.color(255, 255, 191, 0);
 
@@ -112,14 +112,14 @@ public class FoodHUD implements ClientGuiEvent.RenderHud
         pose.scale(scale, scale, scale);
         pose.translate(startWidth * (useLargeIcons ? 0.3333f : 1f), height * (useLargeIcons ? 0.3333f : 1f), 0f);
 
-        if (food.item == Items.CAKE && Platform.isModLoaded("farmersdelight"))
+        if (food.item.is(Items.CAKE) && Platform.isModLoaded("farmersdelight"))
         {
             var cakeSlice = SOLValheim.ITEMS.getRegistrar().get(new ResourceLocation("farmersdelight:cake_slice"));
-            renderGUIItem(graphics, new ItemStack(cakeSlice == null ? food.item : cakeSlice, 1), startWidth + 1, height + 1);
+            renderGUIItem(graphics, cakeSlice != null ? new ItemStack(cakeSlice, 1) : food.item, startWidth + 1, height + 1);
         }
         else
         {
-            renderGUIItem(graphics, new ItemStack(food.item, 1), startWidth + 1, height + 1);
+            renderGUIItem(graphics, food.item, startWidth + 1, height + 1);
         }
 
         pose.pushPose();

--- a/common/src/main/java/vice/sol_valheim/ModConfig.java
+++ b/common/src/main/java/vice/sol_valheim/ModConfig.java
@@ -13,8 +13,10 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.UseAnim;
+import vice.sol_valheim.api.FoodPropertiesGetter;
 
 import java.util.*;
 
@@ -22,8 +24,8 @@ import java.util.*;
 @Config(name = SOLValheim.MOD_ID)
 @Config.Gui.Background("minecraft:textures/block/stone.png")
 public class ModConfig extends PartitioningSerializer.GlobalData {
-
-    public static Common.FoodConfig getFoodConfig(Item item) {
+    public static Common.FoodConfig getFoodConfig(ItemStack stack) {
+        var item = stack.getItem();
         var isDrink = item.getDefaultInstance().getUseAnimation() == UseAnim.DRINK;
         if(item != Items.CAKE && !item.isEdible() && !isDrink)
             return null;
@@ -35,7 +37,7 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
 
             var food = item == Items.CAKE
                     ? new FoodProperties.Builder().nutrition(10).saturationMod(0.7f).build()
-                    : item.getFoodProperties();
+                    : SOLValheim.getter.get(stack);
 
             if (isDrink) {
                 if (registry.contains("potion")) {
@@ -71,8 +73,6 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
                 effectConfig.ID = BuiltInRegistries.MOB_EFFECT.getKey(MobEffects.MOVEMENT_SPEED).toString();
                 existing.extraEffects.add(effectConfig);
             }
-
-            SOLValheim.Config.common.foodConfigs.put(item.arch$registryName().toString(), existing);
         }
 
         return existing;

--- a/common/src/main/java/vice/sol_valheim/SOLValheim.java
+++ b/common/src/main/java/vice/sol_valheim/SOLValheim.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.*;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
+import vice.sol_valheim.api.FoodPropertiesGetter;
 
 import java.util.List;
 
@@ -47,34 +48,16 @@ public class SOLValheim
 		return speedBuff;
 	}
 
+	public static FoodPropertiesGetter getter;
 
-	public static void init() {
+	public static void init(FoodPropertiesGetter getter) {
 		EntityDataSerializers.registerSerializer(ValheimFoodData.FOOD_DATA_SERIALIZER);
 
 		AutoConfig.register(ModConfig.class, PartitioningSerializer.wrap(JanksonConfigSerializer::new));
 		Config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 
-		boolean addedAny = false;
-
-    	#if PRE_CURRENT_MC_1_19_2
-		for (Item item : Registry.ITEM) {
-    	#elif POST_CURRENT_MC_1_20_1
-		for (Item item : BuiltInRegistries.ITEM) {
-		#endif
-			var key = item.arch$registryName();
-			var existing = Config.common.foodConfigs.get(key);
-			if (existing == null) {
-				ModConfig.getFoodConfig(item);
-				addedAny = true;
-			}
-		}
-
-		if (addedAny) {
-			//System.out.println("Generated config for missing items...");
-			AutoConfig.getConfigHolder(ModConfig.class).save();
-		}
+		SOLValheim.getter = getter;
 	}
-
 
 
 	public static void addTooltip(ItemStack item, TooltipFlag flag, List<Component> list){
@@ -84,7 +67,7 @@ public class SOLValheim
 			return;
 		}
 
-		var config = ModConfig.getFoodConfig(food);
+		var config = ModConfig.getFoodConfig(item);
 		if (config == null)
 			return;
 

--- a/common/src/main/java/vice/sol_valheim/api/FoodPropertiesGetter.java
+++ b/common/src/main/java/vice/sol_valheim/api/FoodPropertiesGetter.java
@@ -1,0 +1,8 @@
+package vice.sol_valheim.api;
+
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.ItemStack;
+
+public interface FoodPropertiesGetter {
+    FoodProperties get(ItemStack stack);
+}

--- a/common/src/main/java/vice/sol_valheim/mixin/CakeBlockMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/CakeBlockMixin.java
@@ -20,13 +20,13 @@ public class CakeBlockMixin
     private static void canEatCake(LevelAccessor level, BlockPos pos, BlockState state, Player player, CallbackInfoReturnable<InteractionResult> cir)
     {
         var foodData = ((PlayerEntityMixinDataAccessor) player).sol_valheim$getFoodData();
-        var canEat = foodData.canEat(Items.CAKE);
+        var canEat = foodData.canEat(Items.CAKE.getDefaultInstance());
         if (canEat)
         {
             if (level.isClientSide())
                 return;
 
-            foodData.eatItem(Items.CAKE);
+            foodData.eatItem(Items.CAKE.getDefaultInstance());
             return;
         }
 

--- a/common/src/main/java/vice/sol_valheim/mixin/FoodDataMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/FoodDataMixin.java
@@ -35,7 +35,7 @@ public class FoodDataMixin implements FoodDataPlayerAccessor
         }
 
         var foodData = ((PlayerEntityMixinDataAccessor) sol_valheim$player).sol_valheim$getFoodData();
-        if (foodData.canEat(item))
-            foodData.eatItem(item);
+        if (foodData.canEat(stack))
+            foodData.eatItem(stack);
     }
 }

--- a/common/src/main/java/vice/sol_valheim/mixin/ItemMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/ItemMixin.java
@@ -32,7 +32,7 @@ public class ItemMixin
                 return;
             }
 
-            var canEat = ((PlayerEntityMixinDataAccessor) player).sol_valheim$getFoodData().canEat(item);
+            var canEat = ((PlayerEntityMixinDataAccessor) player).sol_valheim$getFoodData().canEat(itemStack);
             if (canEat || item.getFoodProperties().canAlwaysEat()) {
                 player.startUsingItem(usedHand);
 

--- a/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
@@ -68,7 +68,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
             return;
         }
 
-        sol_valheim$food_data.eatItem(stack.getItem());
+        sol_valheim$food_data.eatItem(stack);
         sol_valheim$trackData();
     }
 

--- a/common/src/main/java/vice/sol_valheim/mixin/ServerPlayerMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/ServerPlayerMixin.java
@@ -18,7 +18,7 @@ public class ServerPlayerMixin
         var useItem = player.getUseItem();
         if (!useItem.isEmpty() && player.isUsingItem() && useItem.getUseAnimation() == UseAnim.DRINK)
         {
-            ((PlayerEntityMixinDataAccessor) player).sol_valheim$getFoodData().eatItem(useItem.getItem());
+            ((PlayerEntityMixinDataAccessor) player).sol_valheim$getFoodData().eatItem(useItem);
         }
     }
 }

--- a/fabric/src/main/java/vice/sol_valheim/fabric/FabricInitializer.java
+++ b/fabric/src/main/java/vice/sol_valheim/fabric/FabricInitializer.java
@@ -6,6 +6,6 @@ import net.fabricmc.api.ModInitializer;
 public class FabricInitializer implements ModInitializer {
     @Override
     public void onInitialize() {
-        SOLValheim.init();
+        SOLValheim.init((stack) -> stack.getItem().getFoodProperties());
     }
 }

--- a/forge/src/main/java/vice/sol_valheim/forge/ForgeInitializer.java
+++ b/forge/src/main/java/vice/sol_valheim/forge/ForgeInitializer.java
@@ -11,6 +11,7 @@ public class ForgeInitializer
     public ForgeInitializer() {
 		// Submit our event bus to let architectury register our content on the right time
         EventBuses.registerModEventBus(SOLValheim.MOD_ID, FMLJavaModLoadingContext.get().getModEventBus());
-        SOLValheim.init();
+        SOLValheim.init((stack) -> stack.getFoodProperties(null));
     }
+
 }


### PR DESCRIPTION
This adds support for the forge `getFoodProperties` method on item stacks, allowing mods like [Some Assembly Required](https://www.curseforge.com/minecraft/mc-mods/some-assembly-required) to work with this mod.
This also removes the automatic generation of food configs on mod initialization, and the subsequent caching of said configs. Ultimately, I feel removing these is of little consequence, as users can write their own configs to disable certain behavior, and creating these configs is not a particularly expensive operation.