### PR TITLE
Fix: NullPointerException in Minecolonies GUI (v1.2.1) and related food sync issues

### DIFF
--- a/common/src/main/java/vice/sol_valheim/ModConfig.java
+++ b/common/src/main/java/vice/sol_valheim/ModConfig.java
@@ -24,60 +24,76 @@ import java.util.*;
 @Config(name = SOLValheim.MOD_ID)
 @Config.Gui.Background("minecraft:textures/block/stone.png")
 public class ModConfig extends PartitioningSerializer.GlobalData {
-    public static Common.FoodConfig getFoodConfig(ItemStack stack) {
-        var item = stack.getItem();
-        var isDrink = item.getDefaultInstance().getUseAnimation() == UseAnim.DRINK;
-        if(item != Items.CAKE && !item.isEdible() && !isDrink)
-            return null;
+	public static Common.FoodConfig getFoodConfig(ItemStack stack) {
+    // --- 關鍵修改 1：即使 stack 數量為 0 (isEmpty)，只要它不是 AIR 且有 Item 物件，就應該繼續執行 ---
+    if (stack == null) return null;
+    var item = stack.getItem();
+    if (item == Items.AIR) return null; 
 
-        var existing = SOLValheim.Config.common.foodConfigs.get(item.arch$registryName().toString());
-        if (existing == null)
-        {
-            var registry = item.arch$registryName().toString();
+    // 原本你可能有用 stack.isEdible()，但在最後一個食物被吃掉時，
+    // 部分版本的 stack.isEdible() 可能會因為數量為 0 而判斷失敗。
+    // 建議改用 item 級別的判斷：
+    var isDrink = item.getDefaultInstance().getUseAnimation() == UseAnim.DRINK;
+    
+    // 判斷是否為可進食/飲用物品
+    if (item != Items.CAKE && !item.isEdible() && !isDrink)
+        return null;
 
-            var food = item == Items.CAKE
-                    ? new FoodProperties.Builder().nutrition(10).saturationMod(0.7f).build()
-                    : SOLValheim.getter.get(stack);
+    var existing = SOLValheim.Config.common.foodConfigs.get(item.arch$registryName().toString());
+    if (existing == null) {
+        var registry = item.arch$registryName().toString();
 
-            if (isDrink) {
-                if (registry.contains("potion")) {
-                    food = new FoodProperties.Builder().nutrition(4).saturationMod(0.75f).build();
-                }
-                else if (registry.contains("milk")) {
-                    food = new FoodProperties.Builder().nutrition(6).saturationMod(1f).build();
-                }
-                else {
-                    food = new FoodProperties.Builder().nutrition(2).saturationMod(0.5f).build();
-                }
+        // --- 關鍵修改 2：獲取 FoodProperties 時，如果 stack 已經 empty，使用 item.getDefaultInstance() ---
+        // 這樣可以確保即便手上那個 stack 消失了，我們還能拿到該物品的原始屬性
+        ItemStack referenceStack = stack.isEmpty() ? item.getDefaultInstance() : stack;
+
+        var food = item == Items.CAKE
+                ? new FoodProperties.Builder().nutrition(10).saturationMod(0.7f).build()
+                : SOLValheim.getter.get(referenceStack);
+
+        // 如果 getter 沒抓到，給個保底，避免後續 NullPointerException
+        if (food == null) {
+            food = new FoodProperties.Builder().nutrition(2).saturationMod(0.1f).build();
+        }
+
+        if (isDrink) {
+            if (registry.contains("potion")) {
+                food = new FoodProperties.Builder().nutrition(4).saturationMod(0.75f).build();
             }
-
-            existing = new Common.FoodConfig();
-            existing.nutrition = food.getNutrition();
-            existing.healthRegenModifier = 1f;
-            existing.saturationModifier = food.getSaturationModifier();
-
-            if (registry.startsWith("farmers"))
-            {
-                existing.nutrition = (int) ((existing.nutrition * 1.25));
-                existing.saturationModifier = existing.saturationModifier * 1.10f;
-                existing.healthRegenModifier = 1.25f;
+            else if (registry.contains("milk")) {
+                food = new FoodProperties.Builder().nutrition(6).saturationMod(1f).build();
             }
-
-            if (registry.equals("minecraft:golden_apple") || registry.equals("minecraft:enchanted_golden_apple")) {
-                existing.nutrition = 10;
-                existing.healthRegenModifier = 1.5f;
-            }
-
-            if (registry.equals("minecraft:beetroot_soup")) {
-                var effectConfig = new Common.MobEffectConfig();
-                effectConfig.ID = BuiltInRegistries.MOB_EFFECT.getKey(MobEffects.MOVEMENT_SPEED).toString();
-                existing.extraEffects.add(effectConfig);
+            else {
+                food = new FoodProperties.Builder().nutrition(2).saturationMod(0.5f).build();
             }
         }
 
-        return existing;
+        existing = new Common.FoodConfig();
+        existing.nutrition = food.getNutrition();
+        existing.healthRegenModifier = 1f;
+        existing.saturationModifier = food.getSaturationModifier();
+
+        // ...（後續的 farmers delight 或金蘋果判斷邏輯保持不變）...
+        if (registry.startsWith("farmers")) {
+            existing.nutrition = (int) ((existing.nutrition * 1.25));
+            existing.saturationModifier = existing.saturationModifier * 1.10f;
+            existing.healthRegenModifier = 1.25f;
+        }
+
+        if (registry.equals("minecraft:golden_apple") || registry.equals("minecraft:enchanted_golden_apple")) {
+            existing.nutrition = 10;
+            existing.healthRegenModifier = 1.5f;
+        }
+
+        if (registry.equals("minecraft:beetroot_soup")) {
+            var effectConfig = new Common.MobEffectConfig();
+            effectConfig.ID = BuiltInRegistries.MOB_EFFECT.getKey(MobEffects.MOVEMENT_SPEED).toString();
+            existing.extraEffects.add(effectConfig);
+        }
     }
 
+    return existing;
+}
 
     @ConfigEntry.Category("common")
     @ConfigEntry.Gui.TransitiveObject()

--- a/common/src/main/java/vice/sol_valheim/SOLValheim.java
+++ b/common/src/main/java/vice/sol_valheim/SOLValheim.java
@@ -61,6 +61,20 @@ public class SOLValheim
 
 
 	public static void addTooltip(ItemStack item, TooltipFlag flag, List<Component> list){
+
+		if (item == null || item.isEmpty())
+			return;
+
+		if (!item.isEdible())
+			return;
+
+		if (getter == null)
+			return;
+
+		var foodProps = getter.get(item);
+		if (foodProps == null)
+			return;
+
 		var food = item.getItem();
 		if (food == Items.ROTTEN_FLESH) {
 			list.add(Component.literal("☠ Empties Your Stomach!").withStyle(ChatFormatting.GREEN));
@@ -71,36 +85,59 @@ public class SOLValheim
 		if (config == null)
 			return;
 
-		var hearts = config.getHearts() % 2 == 0 ? config.getHearts() / 2 : String.format("%.1f", (float) config.getHearts() / 2f);
-		list.add(Component.literal("❤ " + hearts + " Heart" + (config.getHearts() / 2f > 1 ? "s" : "")).withStyle(ChatFormatting.RED));
-		list.add(Component.literal("☀ " + String.format("%.1f", config.getHealthRegen()) + " Regen").withStyle(ChatFormatting.DARK_RED));
+		var hearts = config.getHearts() % 2 == 0
+				? config.getHearts() / 2
+				: String.format("%.1f", (float) config.getHearts() / 2f);
+
+		list.add(Component.literal("❤ " + hearts + " Heart" +
+				(config.getHearts() / 2f > 1 ? "s" : ""))
+				.withStyle(ChatFormatting.RED));
+
+		list.add(Component.literal("☀ " +
+				String.format("%.1f", config.getHealthRegen()) +
+				" Regen")
+				.withStyle(ChatFormatting.DARK_RED));
 
 		var minutes = (float) config.getTime() / (20 * 60);
 
-		list.add(Component.literal("⌚ " + String.format("%.0f", minutes)  + " Minute" + (minutes > 1 ? "s" : "")).withStyle(ChatFormatting.GOLD));
+		list.add(Component.literal("⌚ " +
+				String.format("%.0f", minutes) +
+				" Minute" +
+				(minutes > 1 ? "s" : ""))
+				.withStyle(ChatFormatting.GOLD));
 
 		if(!config.extraEffects.isEmpty() && Config.common.displayEffects) {
 			list.add(Component.literal(""));
+
 			for (var effect : config.extraEffects) {
 				var eff = effect.getEffect();
 				if (eff == null)
 					continue;
 
-				float effectDurationSeconds = config.getTime() * effect.duration / 20f;
+				float effectDurationSeconds =
+						config.getTime() * effect.duration / 20f;
+
 				int minutesPart = (int) (effectDurationSeconds / 60);
 				int secondsPart = (int) (effectDurationSeconds % 60);
 
-
 				if (eff.isBeneficial())
-					list.add(Component.literal("★ " + eff.getDisplayName().getString() + (effect.amplifier > 1 ? " " + effect.amplifier : "") +  String.format(" (%02d:%02d)", minutesPart, secondsPart)).withStyle(ChatFormatting.GREEN));
+					list.add(Component.literal("★ " +
+							eff.getDisplayName().getString() +
+							(effect.amplifier > 1 ? " " + effect.amplifier : "") +
+							String.format(" (%02d:%02d)", minutesPart, secondsPart))
+							.withStyle(ChatFormatting.GREEN));
 				else
-					list.add(Component.literal("❌ " + eff.getDisplayName().getString() + (effect.amplifier > 1 ? " " + effect.amplifier : "") + String.format(" (%02d:%02d)", minutesPart, secondsPart)).withStyle(ChatFormatting.DARK_RED));
+					list.add(Component.literal("❌ " +
+							eff.getDisplayName().getString() +
+							(effect.amplifier > 1 ? " " + effect.amplifier : "") +
+							String.format(" (%02d:%02d)", minutesPart, secondsPart))
+							.withStyle(ChatFormatting.DARK_RED));
 			}
 		}
 
 		if (item.getUseAnimation() == UseAnim.DRINK) {
-			list.add(Component.literal("❄ Refreshing!").withStyle(ChatFormatting.AQUA));
-
+			list.add(Component.literal("❄ Refreshing!")
+					.withStyle(ChatFormatting.AQUA));
 		}
 	}
 }

--- a/common/src/main/java/vice/sol_valheim/ValheimFoodData.java
+++ b/common/src/main/java/vice/sol_valheim/ValheimFoodData.java
@@ -47,56 +47,51 @@ public class ValheimFoodData
     public EatenFoodItem DrinkSlot;
     public int MaxItemSlots = SOLValheim.Config.common.maxSlots;
 
-    public void eatItem(ItemStack food)
-    {
-        if (food.is(Items.ROTTEN_FLESH))
-            return;
+	public void eatItem(ItemStack food)	{
+		// 增加：防禦性檢查，如果物品真的空了，就不執行任何邏輯
+		if (food == null || food.isEmpty()) return;
 
-        var config = ModConfig.getFoodConfig(food);
-        if (config == null)
-            return;
+		if (food.is(Items.ROTTEN_FLESH))
+			return;
 
-        var isDrink = food.getUseAnimation() == UseAnim.DRINK;
-        if (isDrink) {
-            if (DrinkSlot != null && !DrinkSlot.canEatEarly())
-                return;
+		var config = ModConfig.getFoodConfig(food);
+		if (config == null)
+			return;
 
-            if (DrinkSlot == null)
-                DrinkSlot = new EatenFoodItem(food, config.getTime());
-            else {
-                DrinkSlot.ticksLeft = config.getTime();
-                DrinkSlot.item = food;
-            }
+		var isDrink = food.getUseAnimation() == UseAnim.DRINK;
+		if (isDrink) {
+			if (DrinkSlot != null && !DrinkSlot.canEatEarly())
+				return;
 
-            return;
-        }
+			// 確保建立一個新的副本，避免引用原始已歸零的 stack
+			DrinkSlot = new EatenFoodItem(food.copy(), config.getTime());
+			return;
+		}
 
-        var existing = getEatenFood(food);
-        if (existing != null)
-        {
-            if (!existing.canEatEarly())
-                return;
+		var existing = getEatenFood(food);
+		if (existing != null) {
+			if (!existing.canEatEarly()) return;
+			existing.ticksLeft = config.getTime();
+			existing.item = food.copy(); // 使用副本
+			return;
+		}
 
-            existing.ticksLeft = config.getTime();
-            return;
-        }
+		if (ItemEntries.size() < MaxItemSlots)
+		{
+			ItemEntries.add(new EatenFoodItem(food.copy(), config.getTime()));
+			return;
+		}
 
-        if (ItemEntries.size() < MaxItemSlots)
-        {
-            ItemEntries.add(new EatenFoodItem(food, config.getTime()));
-            return;
-        }
-
-        for (var item : ItemEntries)
-        {
-            if (item.canEatEarly())
-            {
-                item.ticksLeft = config.getTime();
-                item.item = food;
-                return;
-            }
-        }
-    }
+		for (var item : ItemEntries)
+		{
+			if (item.canEatEarly())
+			{
+				item.ticksLeft = config.getTime();
+				item.item = food.copy(); // 使用副本
+				return;
+			}
+		}
+	}
 
     public boolean canEat(ItemStack food)
     {
@@ -116,13 +111,12 @@ public class ValheimFoodData
         return ItemEntries.stream().anyMatch(EatenFoodItem::canEatEarly);
     }
 
-    public EatenFoodItem getEatenFood(ItemStack food) {
-        return ItemEntries.stream()
-                .filter((item) -> item.item == food)
-                .findFirst()
-                .orElse(null);
-    }
-
+	public EatenFoodItem getEatenFood(ItemStack food) {
+		return ItemEntries.stream()
+				.filter(item -> ItemStack.isSameItemSameTags(item.item, food))
+				.findFirst()
+				.orElse(null);
+	}
 
     public void clear()
     {
@@ -131,22 +125,18 @@ public class ValheimFoodData
     }
 
 
-    public void tick()
-    {
-        for (var item : ItemEntries)
-        {
-            item.ticksLeft--;
-        }
+	public void tick() {
+		// 確保 ticksLeft 不會減到負數，且移除 <= 0 的物件
+		ItemEntries.removeIf(item -> {
+			item.ticksLeft--;
+			return item.ticksLeft <= 0;
+		});
 
-        if (DrinkSlot != null) {
-            DrinkSlot.ticksLeft--;
-            if (DrinkSlot.ticksLeft <= 0)
-                DrinkSlot = null;
-        }
-
-        ItemEntries.removeIf(item -> item.ticksLeft <= 0);
-        ItemEntries.sort(Comparator.comparingInt(a -> a.ticksLeft));
-    }
+		if (DrinkSlot != null) {
+			DrinkSlot.ticksLeft--;
+			if (DrinkSlot.ticksLeft <= 0) DrinkSlot = null;
+		}
+	}
 
 
     public float getTotalFoodNutrition()
@@ -218,15 +208,15 @@ public class ValheimFoodData
             count++;
         }
 
-        if (DrinkSlot != null)
-        {
-            tag.putString("drink", DrinkSlot.item.getItem().arch$registryName().toString());
-            CompoundTag stackData = DrinkSlot.item.getTag();
-            if (stackData != null) {
-                tag.put("drinkData" + count, stackData);
-            }
-            tag.putInt("drinkticks", DrinkSlot.ticksLeft);
-        }
+		if (DrinkSlot != null)
+		{
+			tag.putString("drink", DrinkSlot.item.getItem().arch$registryName().toString());
+			CompoundTag stackData = DrinkSlot.item.getTag();
+			if (stackData != null) {
+				tag.put("drinkData", stackData); // 移除 + count，使用固定標籤
+			}
+			tag.putInt("drinkticks", DrinkSlot.ticksLeft);
+		}
 
         return tag;
     }
@@ -250,20 +240,17 @@ public class ValheimFoodData
             instance.ItemEntries.add(new EatenFoodItem(stack, ticks));
         }
 
-        var drink = tag.getString("drink");
         var drinkTicks = tag.getInt("drinkticks");
-
-        if (!drink.isBlank())
-        {
-            var item = SOLValheim.ITEMS.getRegistrar().get(new ResourceLocation(drink));
-            var stack = new ItemStack(item, 1);
-
-            if (tag.contains("drinkData")) {
-                var data = tag.getCompound("drinkData");
-                stack.setTag(data);
-            }
-            instance.DrinkSlot = new EatenFoodItem(stack, drinkTicks);
-        }
+		var drink = tag.getString("drink");
+		if (!drink.isBlank())
+		{
+			var item = SOLValheim.ITEMS.getRegistrar().get(new ResourceLocation(drink));
+			var stack = new ItemStack(item, 1);
+			if (tag.contains("drinkData")) { // 名稱需與 save 一致
+				stack.setTag(tag.getCompound("drinkData"));
+			}
+			instance.DrinkSlot = new EatenFoodItem(stack, tag.getInt("drinkticks"));
+		}
 
         return instance;
     }
@@ -284,16 +271,19 @@ public class ValheimFoodData
             return ((float) this.ticksLeft / config.getTime()) < SOLValheim.Config.common.eatAgainPercentage;
         }
 
-        public EatenFoodItem(ItemStack item, int ticksLeft)
-        {
-            this.item = item;
-            this.ticksLeft = ticksLeft;
-        }
+		public EatenFoodItem(ItemStack item, int ticksLeft)
+		{
+			this.item = item.copy();
+			this.item.setCount(1); // 強制數量為 1，防止變為空物品
+			this.ticksLeft = ticksLeft;
+		}
 
-        public EatenFoodItem(EatenFoodItem eaten)
-        {
-            this.item = eaten.item;
-            this.ticksLeft = eaten.ticksLeft;
-        }
+		public EatenFoodItem(EatenFoodItem eaten)
+		{
+			// 必須也使用 copy 並確保數量
+			this.item = eaten.item.copy();
+			this.item.setCount(1);
+			this.ticksLeft = eaten.ticksLeft;
+		}
     }
 }

--- a/common/src/main/java/vice/sol_valheim/accessors/PlayerEntityMixinDataAccessor.java
+++ b/common/src/main/java/vice/sol_valheim/accessors/PlayerEntityMixinDataAccessor.java
@@ -6,7 +6,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import vice.sol_valheim.ValheimFoodData;
 
-public interface PlayerEntityMixinDataAccessor
-{
+public interface PlayerEntityMixinDataAccessor {
+    // 獲取食物數據
     ValheimFoodData sol_valheim$getFoodData();
+
+    // 新增：定義重新整理（同步）數據的方法，這將解決編譯錯誤
+    void sol_valheim$refreshFoodData();
 }

--- a/common/src/main/java/vice/sol_valheim/mixin/FoodDataMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/FoodDataMixin.java
@@ -4,7 +4,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,6 +11,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import vice.sol_valheim.accessors.FoodDataPlayerAccessor;
 import vice.sol_valheim.accessors.PlayerEntityMixinDataAccessor;
+import vice.sol_valheim.ValheimFoodData;
+import vice.sol_valheim.ModConfig; // <--- 必須加上這一行
+import vice.sol_valheim.SOLValheim; // <--- 建議也加上，如果後面有用到
 
 @Mixin(FoodData.class)
 public class FoodDataMixin implements FoodDataPlayerAccessor
@@ -25,17 +27,44 @@ public class FoodDataMixin implements FoodDataPlayerAccessor
     @Override
     public void sol_valheim$setPlayer(Player player) { sol_valheim$player = player; }
 
-    @Inject(at = @At("HEAD"), method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V")
-    public void onEatFood(Item item, ItemStack stack, CallbackInfo ci)
-    {
-        if (sol_valheim$player == null)
-        {
-            System.out.println("sol_valheim$player is null in FoodData, this should never happen!");
-            return;
-        }
+	@Inject(at = @At("HEAD"), method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V")
+	public void onEatFood(Item item, ItemStack stack, CallbackInfo ci)
+	{
+		if (sol_valheim$player == null || sol_valheim$player.level().isClientSide) return;
 
-        var foodData = ((PlayerEntityMixinDataAccessor) sol_valheim$player).sol_valheim$getFoodData();
-        if (foodData.canEat(stack))
-            foodData.eatItem(stack);
+		ItemStack realFoodStack;
+		
+		// 優先判斷傳入的 stack，但如果它已經空了(數量變0)，就用傳入的 item 重新建立一個
+		if (stack != null && !stack.isEmpty()) {
+			realFoodStack = stack.copy(); // 建議 copy 一份，避免後續邏輯影響原始 stack
+		} else if (item != null) {
+			realFoodStack = new ItemStack(item);
+		} else {
+			return;
+		}
+
+		// 強制確保數量為 1，這是防止「佔 HUD 沒效果」的保險
+		if (realFoodStack.getCount() <= 0) {
+			realFoodStack.setCount(1);
+		}
+
+		var accessor = (PlayerEntityMixinDataAccessor) sol_valheim$player;
+		var foodData = accessor.sol_valheim$getFoodData();
+		
+		// 檢查 Config 是否存在
+		if (ModConfig.getFoodConfig(realFoodStack) != null) {
+			foodData.eatItem(realFoodStack);
+			
+			// 呼叫同步
+			accessor.sol_valheim$refreshFoodData();
+		}
+	}
+
+    @Unique
+    private void sol_valheim$syncToClient() {
+        // 透過介面轉型呼叫 PlayerEntityMixin 裡的 refreshFoodData
+        if (sol_valheim$player instanceof PlayerEntityMixinDataAccessor accessor) {
+            accessor.sol_valheim$refreshFoodData();
+        }
     }
 }

--- a/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
@@ -29,25 +29,36 @@ import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 @Mixin({Player.class})
-public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEntityMixinDataAccessor
-{
-    @Unique
-    private static final EntityDataAccessor<ValheimFoodData> sol_valheim$DATA_ACCESSOR = SynchedEntityData.defineId(Player.class, ValheimFoodData.FOOD_DATA_SERIALIZER);
+public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEntityMixinDataAccessor {
 
-    @Shadow
-    protected FoodData foodData;
-
-    @Override
+    // --- 補回這一段，這是 DataTracker 的核心 ---
     @Unique
-    public ValheimFoodData sol_valheim$getFoodData() {
-        var player = (Player) (LivingEntity)this;
-        return player.getEntityData().get(sol_valheim$DATA_ACCESSOR);
-    }
+    private static final EntityDataAccessor<ValheimFoodData> sol_valheim$DATA_ACCESSOR = 
+        SynchedEntityData.defineId(Player.class, ValheimFoodData.FOOD_DATA_SERIALIZER);
+    // ------------------------------------------
 
     @Unique
     private ValheimFoodData sol_valheim$food_data = new ValheimFoodData();
 
-    protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType, Level level) { super(entityType, level); }
+    @Shadow
+    protected FoodData foodData;
+
+    protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType, Level level) { 
+        super(entityType, level); 
+    }
+
+    // 正確實作介面中的同步方法
+    @Override
+    public void sol_valheim$refreshFoodData() {
+        this.sol_valheim$trackData(); 
+    }
+
+    // 實作獲取數據的方法
+    @Override
+    @Unique
+    public ValheimFoodData sol_valheim$getFoodData() {
+        return this.entityData.get(sol_valheim$DATA_ACCESSOR);
+    }
 
     @Inject(at = {@At("HEAD")}, method = {"causeFoodExhaustion(F)V"}, cancellable = true)
     private void onAddExhaustion(float exhaustion, CallbackInfo info) {
@@ -56,8 +67,8 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
 
     @Inject(at = {@At("HEAD")}, method = {"getFoodData"})
     private void onGetFoodData(CallbackInfoReturnable<FoodData> cir) {
-        // hack workaround for player data not being accessible in FoodData
-        ((FoodDataPlayerAccessor) foodData).sol_valheim$setPlayer((Player) (LivingEntity) this);
+        // 確保 FoodData 知道它是屬於哪個 Player 的
+        ((FoodDataPlayerAccessor) foodData).sol_valheim$setPlayer((Player) (Object) this);
     }
 
     @Inject(at = {@At("HEAD")}, method = {"eat(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/item/ItemStack;"})
@@ -85,8 +96,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
         var level = this.level();
         #endif
 
-        if (level.isClientSide)
-            return;
+        if (level.isClientSide) return;
 
         if (isDeadOrDying()) {
             sol_valheim$food_data.clear();
@@ -100,33 +110,23 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
 
             var player = (Player) (Object) this;
             if (player.tickCount % 20 == 0) {
-                // Handle main eaten items
                 for (var eaten : sol_valheim$food_data.ItemEntries) {
                     var config = ModConfig.getFoodConfig(eaten.item);
-                    if (config != null) {
-                        sol_valheim$applyFoodEffectsToPlayer(player, eaten, config);
-                    }
+                    if (config != null) sol_valheim$applyFoodEffectsToPlayer(player, eaten, config);
                 }
-                // Handle drink slot
                 if (sol_valheim$food_data.DrinkSlot != null) {
                     var config = ModConfig.getFoodConfig(sol_valheim$food_data.DrinkSlot.item);
-                    if (config != null) {
-                        sol_valheim$applyFoodEffectsToPlayer(player, sol_valheim$food_data.DrinkSlot, config);
-                    }
+                    if (config != null) sol_valheim$applyFoodEffectsToPlayer(player, sol_valheim$food_data.DrinkSlot, config);
                 }
             }
         }
 
         float maxhp = Math.min(SOLValheim.Config.common.maxFoodHealth * 2, (SOLValheim.Config.common.startingHealth * 2) + sol_valheim$food_data.getTotalFoodNutrition());
-        // hack: round to full hearts
         maxhp = Math.round(maxhp / 2) * 2;
 
-        Player player = (Player) (LivingEntity) this;
+        Player player = (Player) (Object) this;
         player.getFoodData().setSaturation(0);
-
         player.getAttribute(Attributes.MAX_HEALTH).setBaseValue(maxhp);
-        //if (getHealth() > maxhp)
-        //    setHealth(maxhp);
 
         if (SOLValheim.Config.common.speedBoost > 0.01f) {
             var attr = player.getAttribute(Attributes.MOVEMENT_SPEED);
@@ -138,41 +138,25 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
         }
 
         var timeSinceHurt = level.getGameTime() - ((LivingEntityDamageAccessor) this).getLastDamageStamp();
-        if (timeSinceHurt > SOLValheim.Config.common.regenDelay && player.tickCount % (5 * SOLValheim.Config.common.regenSpeedModifier) == 0)
-        {
+        if (timeSinceHurt > SOLValheim.Config.common.regenDelay && player.tickCount % (5 * SOLValheim.Config.common.regenSpeedModifier) == 0) {
             player.heal(sol_valheim$food_data.getRegenSpeed() / 20f);
         }
     }
 
     @Unique
-    private void sol_valheim$applyFoodEffectsToPlayer(Player player,
-                                                      ValheimFoodData.EatenFoodItem eatenData,
-                                                      ModConfig.Common.FoodConfig config)
-    {
+    private void sol_valheim$applyFoodEffectsToPlayer(Player player, ValheimFoodData.EatenFoodItem eatenData, ModConfig.Common.FoodConfig config) {
         int ticksLeft = eatenData.ticksLeft;
-
         for (var effectCfg : config.extraEffects) {
             var mobEffect = effectCfg.getEffect();
-            if (mobEffect == null)
-                continue;
+            if (mobEffect == null) continue;
 
             int amplifier = Math.max(effectCfg.amplifier - 1, 0);
-            float fractionActive = effectCfg.duration;
             int totalTime = config.getTime();
-            int threshold = (int) (totalTime * fractionActive);
+            int threshold = (int) (totalTime * effectCfg.duration);
 
             if (ticksLeft >= (totalTime - threshold)) {
-                player.addEffect(
-                        new net.minecraft.world.effect.MobEffectInstance(
-                                mobEffect,
-                                120, // just so it doesn't flash
-                                amplifier,
-                                false,
-                                false
-                        )
-                );
-            }
-            else {
+                player.addEffect(new net.minecraft.world.effect.MobEffectInstance(mobEffect, 120, amplifier, false, false));
+            } else {
                 player.removeEffect(mobEffect);
             }
         }
@@ -186,13 +170,12 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
 
     @Inject(at = {@At("HEAD")}, method = {"hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"}, cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> info) {
-
         #if PRE_CURRENT_MC_1_19_2
         if (source == DamageSource.STARVE) {
         #elif POST_CURRENT_MC_1_20_1
-        if (source == this.damageSources().starve()) {
+        if (source.is(net.minecraft.world.damagesource.DamageTypes.STARVE)) {
         #endif
-            info.setReturnValue(Boolean.FALSE);
+            info.setReturnValue(false);
             info.cancel();
         }
     }
@@ -204,36 +187,25 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
 
     @Inject(at = {@At("TAIL")}, method = {"readAdditionalSaveData(Lnet/minecraft/nbt/CompoundTag;)V"})
     private void onReadCustomData(CompoundTag nbt, CallbackInfo info) {
-        if (sol_valheim$food_data == null)
-            sol_valheim$food_data = new ValheimFoodData();
-
-        var foodData = ValheimFoodData.read(nbt.getCompound("sol_food_data"));
-        sol_valheim$food_data.MaxItemSlots = foodData.MaxItemSlots;
-        sol_valheim$food_data.DrinkSlot = foodData.DrinkSlot;
-        sol_valheim$food_data.ItemEntries = foodData.ItemEntries.stream()
-                .map(ValheimFoodData.EatenFoodItem::new)
-                .collect(Collectors.toCollection(ArrayList::new));
-
+        if (nbt.contains("sol_food_data")) {
+            this.sol_valheim$food_data = ValheimFoodData.read(nbt.getCompound("sol_food_data"));
+        }
         sol_valheim$trackData();
     }
 
     @Unique
     private void sol_valheim$trackData() {
-
-        #if PRE_CURRENT_MC_1_19_2
-        this.entityData.set(sol_valheim$DATA_ACCESSOR, sol_valheim$food_data);
-        #elif POST_CURRENT_MC_1_20_1
-        this.entityData.set(sol_valheim$DATA_ACCESSOR, sol_valheim$food_data, true);
-        #endif
-
-
+        if (this.entityData != null) {
+            #if PRE_CURRENT_MC_1_19_2
+            this.entityData.set(sol_valheim$DATA_ACCESSOR, sol_valheim$food_data);
+            #elif POST_CURRENT_MC_1_20_1
+            this.entityData.set(sol_valheim$DATA_ACCESSOR, sol_valheim$food_data, true);
+            #endif
+        }
     }
 
     @Inject(at = {@At("TAIL")}, method = {"defineSynchedData"})
     private void onInitDataTracker(CallbackInfo info) {
-        if (sol_valheim$food_data == null)
-            sol_valheim$food_data = new ValheimFoodData();
-
-        this.entityData.define(sol_valheim$DATA_ACCESSOR, sol_valheim$food_data);
+        this.entityData.define(sol_valheim$DATA_ACCESSOR, new ValheimFoodData());
     }
 }

--- a/forge/src/main/java/vice/sol_valheim/forge/ClientEvents.java
+++ b/forge/src/main/java/vice/sol_valheim/forge/ClientEvents.java
@@ -5,15 +5,18 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent; // 確保有這個
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import vice.sol_valheim.SOLValheim;
 
-
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = "sol_valheim", value = {Dist.CLIENT}, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ClientEvents {
+    
+    // 注意：刪除了 PlayerEntityMixinDataAccessor 的 import!
+
     @SubscribeEvent(priority = EventPriority.LOW)
     public static void onItemTooltip(ItemTooltipEvent event) {
         SOLValheim.addTooltip(event.getItemStack(), event.getFlags(), event.getToolTip());
@@ -23,5 +26,13 @@ public class ClientEvents {
     public static void onRenderGUI(RenderGuiOverlayEvent.Pre event) {
         if (event.getOverlay() == VanillaGuiOverlay.FOOD_LEVEL.type())
             event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
+        // 只判斷客戶端，邏輯交給 LogicHandler
+        if (event.getLevel().isClientSide) {
+            LogicHandler.handleRightClick(event);
+        }
     }
 }

--- a/forge/src/main/java/vice/sol_valheim/forge/ForgeInitializer.java
+++ b/forge/src/main/java/vice/sol_valheim/forge/ForgeInitializer.java
@@ -4,14 +4,30 @@ import dev.architectury.platform.forge.EventBuses;
 import vice.sol_valheim.SOLValheim;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.ItemStack;
 
 @Mod(SOLValheim.MOD_ID)
 public class ForgeInitializer
 {
     public ForgeInitializer() {
-		// Submit our event bus to let architectury register our content on the right time
-        EventBuses.registerModEventBus(SOLValheim.MOD_ID, FMLJavaModLoadingContext.get().getModEventBus());
-        SOLValheim.init((stack) -> stack.getFoodProperties(null));
-    }
+        EventBuses.registerModEventBus(
+                SOLValheim.MOD_ID,
+                FMLJavaModLoadingContext.get().getModEventBus()
+        );
 
+        // 修改這裡：移除 Minecraft.getInstance()
+        SOLValheim.init((stack) -> {
+            if (stack == null || stack.isEmpty())
+                return null;
+
+            if (!stack.isEdible())
+                return null;
+
+            // 伺服器端安全的做法：直接從物品獲取屬性，不傳入玩家物件
+            // 注意：某些模組食物可能需要玩家物件才能獲取動態屬性，
+            // 但在伺服器初始化階段通常只能傳 null 或不傳
+            return stack.getFoodProperties(null); 
+        });
+    }
 }

--- a/forge/src/main/java/vice/sol_valheim/forge/LogicHandler.java
+++ b/forge/src/main/java/vice/sol_valheim/forge/LogicHandler.java
@@ -1,0 +1,25 @@
+package vice.sol_valheim.forge;
+
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import vice.sol_valheim.accessors.PlayerEntityMixinDataAccessor; // Import 放在這裡沒關係
+import vice.sol_valheim.ValheimFoodData;
+
+public class LogicHandler {
+    public static void handleRightClick(PlayerInteractEvent.RightClickItem event) {
+        var player = event.getEntity();
+        var stack = event.getItemStack();
+
+        // 只有在執行到這行時，才會去加載 Mixin 介面，避開了啟動時的掃描衝突
+        if (player instanceof PlayerEntityMixinDataAccessor accessor) {
+            ValheimFoodData data = accessor.sol_valheim$getFoodData();
+            if (data != null) {
+                boolean alreadyEatenAndCooling = data.ItemEntries.stream()
+                    .anyMatch(entry -> entry.item.getItem() == stack.getItem() && !entry.canEatEarly());
+
+                if (alreadyEatenAndCooling) {
+                    event.setCanceled(true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses the Null value issues in the Minecolonies GUI for version 1.2.1. It also fixes several side effects caused by the initial null fix, including:
- Ghost eating (eating animation with no item consumed).
- Server-client desync issues.
- Buffs only applying when consuming 2 or more food items.
- Bugs related to consuming "empty" food slots.